### PR TITLE
introduce e_add (one pays for others) + few minor changes/improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ Simple telegram chat bot to track money spending and help with payments.
 
 ## Commands (prototype)
 
-Command                                    | acK | Description
------------------------------------------- | --- | ------------
-`/register`                                |     | Register a user.
-`/join @user` / `/disjoin`                 |  +  | Form a group of users. All transactions are split between users in one group. <br> Ex: `/join @u3`
-`/ack` / `/nack`                           |     | Agree / disagree with the last command.
-`/stat`                                    |     | Show current statistics.
-`/spent [<tx/date_from> [<tx/date_to>]]`   |     | Show logical spending between dates or transactions.
-`/spent c [<tx/date_from> [<tx/date_to>]]` |     | Show cash (real) spending between dates or transactions.
-`/log [@user or me] [num_tx]`              |     | Show last `num_tx` transactions (must be positive integer number, default: 10) for a given @user, self (`me`), or all if omitted. <br> Ex: `/log me 10`.
-`/payment`                                 |     | Show pay-offs.
-`/[g_]add <value> [@user...] [comment]`    |     | Register `value` spending across all or mention users. `g_` modifier to split between groups instead of users. <br> Ex: `/add 10.3 @u1 @u2 Dinner`
-`/cancel <tx> [comment]`                   |  +  | Cancel `tx` transaction (see `/log`). <br> Ex: `/cancel 13 no surfing`
-`/compensate [comment]`                    |  +  | Register pay-off between all users.
+Command                                    | Type     | Description
+------------------------------------------ | -------- | ------------
+`/register`                                | User mgt | Register a user.
+`/join @user` / `/disjoin`                 | User mgt | Form a group of users. All transactions are split between users in one group. <br> Ex: `/join @u3`
+`/stat`                                    | Info     | Show current statistics.
+`/spent [<tx/date_from> [<tx/date_to>]]`   | Info     | Show logical spending between dates or transactions.
+`/spent c [<tx/date_from> [<tx/date_to>]]` | Info     | Show cash (real) spending between dates or transactions.
+`/log [@user or me] [num_tx]`              | Info     | Show last `num_tx` transactions (must be positive integer number, default: 10) for a given @user, self (`me`), or all if omitted. <br> Ex: `/log me 10`.
+`/payment`                                 | Info     | Show pay-offs.
+`/add <value> [@user...] [comment]`        | Action   | Register `value` spending across all or mentioned users. <br> Ex: `/add 10.3 @u1 @u2 Dinner`
+`/g_add <value> [@user...] [comment]`      | Action   | Register `value` spending across groups of all or mentioned users. <br> Ex: `/g_add 10.3 @u1 @u2 House`
+`/cancel <tx> [comment]`                   | Action   | Cancel `tx` transaction (see `/log`). <br> Ex: `/cancel 13 no surfing`
+`/compensate [comment]`                    | Action   | Register pay-off between all users.
 
 ## Model
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Command                                    | Type     | Description
 `/log [@user or me] [num_tx]`              | Info     | Show last `num_tx` transactions (must be positive integer number, default: 10) for a given @user, self (`me`), or all if omitted. <br> Ex: `/log me 10`.
 `/payment`                                 | Info     | Show pay-offs.
 `/add <value> [@user...] [comment]`        | Action   | Register `value` spending across all or mentioned users. <br> Ex: `/add 10.3 @u1 @u2 Dinner`
+`/e_add <value> @user[...] [comment]`      | Action   | Register `value` spending across mentioned users (excluding self). <br> Ex: `/e_add 10.3 @u2 Lunch (u1 pays for u2)`
 `/g_add <value> [@user...] [comment]`      | Action   | Register `value` spending across groups of all or mentioned users. <br> Ex: `/g_add 10.3 @u1 @u2 House`
 `/cancel <tx> [comment]`                   | Action   | Cancel `tx` transaction (see `/log`). <br> Ex: `/cancel 13 no surfing`
 `/compensate [comment]`                    | Action   | Register pay-off between all users.

--- a/src/backend/test/test_tfinance.py
+++ b/src/backend/test/test_tfinance.py
@@ -93,7 +93,7 @@ def test2():
 
 
 def test3():
-    t = gen_tf('test_tf_2.db')
+    t = gen_tf('test_tf_3.db')
     assert t.register(1).ok()
     assert t.register(2).ok()
     assert t.register(3).ok()

--- a/src/backend/tfinance.py
+++ b/src/backend/tfinance.py
@@ -186,7 +186,7 @@ class TFinance:
             this_value = -value_per_user + (value if uid == user_id else 0)
             self.db.add_count(tx_id, uid, this_value)
 
-        return Ok()
+        return Ok(f'tx: {tx_id}')
 
     def e_add(self, user_id, value, other_user_ids, comment=None):
         if not other_user_ids:
@@ -212,7 +212,7 @@ class TFinance:
         for uid in other_user_ids:
             self.db.add_count(tx_id, uid, -value_per_user)
 
-        return Ok()
+        return Ok(f'tx: {tx_id}')
 
     def g_add(self, user_id, value, other_user_ids=None, comment=None):
         r = self.__check_registered(user_id, other_user_ids)
@@ -252,7 +252,7 @@ class TFinance:
             for uid in user_ids:
                 self.db.add_count(tx_id, uid, this_value)
 
-        return Ok()
+        return Ok(f'tx: {tx_id}')
 
     def cancel(self, user_id, tx, comment=None):
         r = self.__check_registered(user_id)
@@ -276,7 +276,7 @@ class TFinance:
 
         self.db.add_counts_with_inverse_values(tx, new_tx_id).unpack()
 
-        return Ok()
+        return Ok(f'tx: {new_tx_id}')
 
     def compensate(self, user_id, comment=None):
         r = self.__check_registered(user_id)
@@ -293,4 +293,4 @@ class TFinance:
             value = self.db.get_user_count_value(user_id)
             if value.bad(): return value
             self.db.add_count(tx_id, user_id, -value.unpack())
-        return Ok()
+        return Ok(f'tx: {tx_id}')

--- a/src/bot.py
+++ b/src/bot.py
@@ -66,7 +66,11 @@ class Bot:
         return 0
 
     def __reply_respond(self, update, respond):
-        if respond.ok(): return self.__reply(update, "success")
+        if respond.ok():
+            r = respond.unpack()
+            message = 'success' + (f'. {r}' if r else '')
+            return self.__reply(update, message)
+
         error = respond.error
         uids = re.findall("%\d+%", error)
         san_uids = ['@' + self.__users[int(uid[1:-1])] for uid in uids]

--- a/src/bot.py
+++ b/src/bot.py
@@ -330,6 +330,23 @@ class Bot:
         self.__reply_respond(update, respond)
 
     @log_info
+    def e_add(self, update, context):
+
+        def usage(update):
+            self.__reply(update, 'usage: /e_add <value> @user[...] [comment]')
+
+        if len(context.args) < 2: return usage(update)
+
+        value = context.args[0]
+        sender_id = self.__get_sender_id(update)
+        mentioned_ids = self.__get_mentioned_ids(update)
+        comment_start = Bot.find_comment_start_pos(update.message.text)
+        lcomment = context.args[comment_start:]
+        respond = self.backend.e_add(sender_id, float(value), mentioned_ids,
+                                     ' '.join(lcomment))
+        self.__reply_respond(update, respond)
+
+    @log_info
     def add(self, update, context):
 
         def usage(update):

--- a/src/bot_manager.py
+++ b/src/bot_manager.py
@@ -31,6 +31,7 @@ class BotManager:
             'log',
             'payment',
             'g_add',
+            'e_add',
             'add',
             'cancel',
             'compensate',

--- a/src/bot_manager.py
+++ b/src/bot_manager.py
@@ -26,8 +26,6 @@ class BotManager:
             'register',
             'join',
             'disjoin',
-            'ack',
-            'nack',
             'stat',
             'spent',
             'log',


### PR DESCRIPTION
Aside from very minor clean-ups (including doc) this PR:
1. Adds `/e_add <val> @user[...] comment` when one pays for others
2. On successful transactions the bot reports `success. tx: <tx_id>` for more convenient search

The PR doesn't change the db structure.

Closes #11.